### PR TITLE
feat: support split components

### DIFF
--- a/src/__tests__/split-component-story/component-browser.ts
+++ b/src/__tests__/split-component-story/component-browser.ts
@@ -1,0 +1,7 @@
+import type EventEmitter from "events";
+
+export default {
+  onMount(this: EventEmitter) {
+    this.emit("mounted");
+  },
+};

--- a/src/__tests__/split-component-story/index.marko
+++ b/src/__tests__/split-component-story/index.marko
@@ -1,0 +1,1 @@
+<div>Hello ${input.name}</div>

--- a/src/__tests__/split-component-story/stories.ts
+++ b/src/__tests__/split-component-story/stories.ts
@@ -1,0 +1,18 @@
+import type { Story, Meta } from "../../client";
+import SplitComponent from "./index.marko";
+
+interface Input {
+  name?: string;
+}
+const Template: Story<Input> = (input) => ({ input });
+
+export default {
+  title: "SplitComponent",
+  component: SplitComponent,
+} as Meta<Input>;
+
+export const HelloWorld = Template.bind({});
+HelloWorld.args = { name: "World" };
+
+export const HelloMarko = Template.bind({});
+HelloMarko.args = { name: "Marko" };

--- a/src/__tests__/split-component-story/test.ts
+++ b/src/__tests__/split-component-story/test.ts
@@ -1,0 +1,65 @@
+import * as assert from "assert";
+import type * as playwright from "playwright";
+import { render, screen } from "@marko/testing-library";
+import * as stories from "./stories";
+import { composeStories } from "../../testing";
+
+const id = "splitcomponent--hello-world";
+
+describe(stories.default.title, () => {
+  describe("iframe", () => {
+    before(async () => {
+      await page.goto(`http://localhost:8080/iframe.html?id=${id}`);
+    });
+
+    it("shows correct name", async () => {
+      const $el = await page.waitForSelector("text=Hello");
+      assert.strictEqual(await $el.innerText(), "Hello World");
+    });
+  });
+
+  describe("addons", () => {
+    let frame: playwright.Frame;
+
+    before(async () => {
+      await page.goto(`http://localhost:8080/?path=/story/${id}`);
+      await page.waitForSelector("#storybook-preview-iframe");
+      frame = page.frame({ name: "storybook-preview-iframe" })!;
+    });
+
+    it("supports controls addon", async () => {
+      const $el = await frame.waitForSelector("text=Hello");
+      await page.click("text=Controls");
+      assert.ok(await page.waitForSelector("text=name"));
+      assert.strictEqual(await $el.innerText(), "Hello World");
+      await page.fill('[placeholder="Adjust string dynamically"]', "Marko");
+      assert.strictEqual(await $el.innerText(), "Hello Marko");
+    });
+
+    it("can navigate to another story", async () => {
+      await Promise.all([
+        frame.waitForNavigation(),
+        page.click("text=Hello Marko"),
+      ]);
+      const $el = await frame.waitForSelector("text=Hello");
+
+      assert.strictEqual(await $el.innerText(), "Hello Marko");
+    });
+  });
+
+  describe("testing", () => {
+    const { HelloWorld, HelloMarko } = composeStories(stories);
+
+    it("can render the hello world story", async () => {
+      await render(HelloWorld);
+      assert.ok(screen.getByText("Hello World"));
+      assert.strictEqual(HelloWorld.args.name, "World");
+    });
+
+    it("can render the hello marko story", async () => {
+      await render(HelloMarko);
+      assert.ok(screen.getByText("Hello Marko"));
+      assert.strictEqual(HelloMarko.args.name, "Marko");
+    });
+  });
+});

--- a/src/client/preview/template.marko
+++ b/src/client/preview/template.marko
@@ -1,0 +1,1 @@
+<${input.component} key="story" ...{ ...input.input }/>


### PR DESCRIPTION
# Issue:
Adds better support for rendering split components in stories.

## What I did
This change switches to a root template that renders the users story instead of directly rendering the user story. This ensures that any type of component can be rerendered on arg changes, such as with split components which do not include their rendering logic.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
