### PR TITLE
fix: default vite allowed hosts config

### DIFF
--- a/.changeset/great-flowers-lie.md
+++ b/.changeset/great-flowers-lie.md
@@ -1,0 +1,5 @@
+---
+"@storybook/marko-vite": minor
+---
+
+When the `--host` cli flag is used with storybook, use that value as a default for the vite `allowedHosts` config.

--- a/packages/frameworks/marko-vite/src/preset.ts
+++ b/packages/frameworks/marko-vite/src/preset.ts
@@ -17,9 +17,12 @@ export const core: PresetProperty<"core"> = async (config, options) => {
   };
 };
 
-export const viteFinal: StorybookConfig["viteFinal"] = async (baseConfig) => {
+export const viteFinal: StorybookConfig["viteFinal"] = async (
+  viteConfig,
+  storybookConfig,
+) => {
   const { mergeConfig } = await import("vite");
-  return mergeConfig(baseConfig, {
+  return mergeConfig(viteConfig, {
     resolve: {
       alias: [
         {
@@ -29,9 +32,13 @@ export const viteFinal: StorybookConfig["viteFinal"] = async (baseConfig) => {
         },
       ],
     },
+    server:
+      storybookConfig.host && viteConfig.server?.allowedHosts === undefined
+        ? { allowedHosts: [storybookConfig.host] }
+        : undefined,
     plugins:
       // Ensure @marko/vite included unless already added.
-      (await hasVitePlugins(baseConfig.plugins || [], ["marko-vite:pre"]))
+      (await hasVitePlugins(viteConfig.plugins || [], ["marko-vite:pre"]))
         ? []
         : [(await import("@marko/vite")).default({ linked: false })],
   });


### PR DESCRIPTION
Updates @storybook/marko-vite to infer the vite `allowedHosts` config from the `--host` storybook cli flag / option.